### PR TITLE
Fixed the 4 of Swords Mercenary value

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -552,7 +552,7 @@
                 "secretText": "The treasure lies in a crypt in Castle Ravenloft (chapter 4, area K84, crypt 31).",
                 "suit": "Swords",
                 "text": "The thing you seek lies with the dead, under mountains of gold coins.",
-                "value": 1
+                "value": 4
             },
             {
                 "key": "myrmidon",


### PR DESCRIPTION
The 4 of Swords is listed as 1 of Swords in the DM text. This fixes the issue.